### PR TITLE
Make ItemStacks draw with an overlay.

### DIFF
--- a/src/main/java/net/glasslauncher/mods/alwaysmoreitems/gui/screen/OverlayScreen.java
+++ b/src/main/java/net/glasslauncher/mods/alwaysmoreitems/gui/screen/OverlayScreen.java
@@ -289,7 +289,7 @@ public class OverlayScreen extends Screen {
                         RenderHelper.enableItemLighting();
                     }
                 }
-                RenderHelper.drawItemStack(item.x, item.y, item.item, false);
+                RenderHelper.drawItemStack(item.x, item.y, item.item, true);
             }
             RenderHelper.disableItemLighting();
         }


### PR DESCRIPTION
Not a big PR, doesn't change any existing Vanilla items. Needed for subtype comprehension.

Old:
![image](https://github.com/user-attachments/assets/a11e0a3f-8c1b-4d35-8eff-d6b53fb46ee5)

New:
![image](https://github.com/user-attachments/assets/944b5dc5-a172-4f3f-830b-78cd9d1e6ba7)


Picture of the entire menu to show Vanilla items remain unchanged.
![image](https://github.com/user-attachments/assets/68759ae0-a399-4d6b-8daa-3125daa3b3b7)
