### PR TITLE
Fix wrong flame icon position

### DIFF
--- a/src/main/java/net/glasslauncher/mods/alwaysmoreitems/plugins/vanilla/furnace/FurnaceSmeltingCategory.java
+++ b/src/main/java/net/glasslauncher/mods/alwaysmoreitems/plugins/vanilla/furnace/FurnaceSmeltingCategory.java
@@ -36,7 +36,7 @@ public class FurnaceSmeltingCategory extends FurnaceRecipeCategory {
 
     @Override
     public void drawAnimations(Minecraft minecraft) {
-        flame.draw(minecraft, 2, 20);
+        flame.draw(minecraft, 1, 20);
         arrow.draw(minecraft, 24, 18);
     }
 


### PR DESCRIPTION
The flame icon for furnace recipes was off by one pixel. This pr moves it by 1 pixel
![picture](https://i.postimg.cc/TYVjmTQt/123123.jpg)